### PR TITLE
add metric wireguard_peer_endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ capabilities in both the ambient and bounding set:
 
 - Total number of bytes transferred in/out per peer
 - Total number of bytes transferred in/out per interface
+- Metrics with the info for each connected peer
 - Time since last handshake per peer
 - Scrape duration in milliseconds
 - Scrape success
@@ -131,6 +132,11 @@ wireguard_peer_bytes_total{direction="tx",interface="custom",peer="N5UQp3XbysLBA
 wireguard_peer_bytes_total{direction="tx",interface="custom",peer="QlgHHfYP3aMlRG7d6/Zp9IhUOLrpT5G2GIdODODaUHQ="} 88648
 wireguard_peer_bytes_total{direction="tx",interface="custom",peer="FtUeMGdNxgkVN0G9lpvOc5jtAQQ1m9DpvZPDCUdKBx0="} 480852300
 wireguard_peer_bytes_total{direction="tx",interface="wg0",peer="bRQZOyOZUvHMhBvCWq2sXO0VsRu6Aq5LCACi/R3AJk8="} 2393043528
+# HELP wireguard_peer_endpoint Peers info. static value
+# TYPE wireguard_peer_endpoint gauge
+wireguard_peer_endpoint{alias="kevin",endpoint_ip="1.1.1.1",interface="custom",peer="q2JWEKWfLPU5UjG2Sq31xx2GsSjdhKNtdT/X/tFVyjs="} 1
+wireguard_peer_endpoint{alias="jane",endpoint_ip="8.8.8.8",interface="custom",peer="2ELWFmGnqhtRpu4r2PUKc0cw+ELtuMPLd6l0KsoCUBQ="} 1
+wireguard_peer_endpoint{alias="robert",endpoint_ip="127.0.0.1",interface="custom",peer="duVVziZbyIiIPoRprisE69K0By198Cn8dPwY5bFecEk="} 1
 # HELP wireguard_peers_total Total number of peers per interfaces
 # TYPE wireguard_peers_total gauge
 wireguard_peers_total{interface="custom"} 7

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -32,10 +32,7 @@ impl Metrics {
         )?;
 
         let peer_endpoint = IntGaugeVec::new(
-            Opts::new(
-                "wireguard_peer_endpoint",
-                "Peers info. static value",
-            ),
+            Opts::new("wireguard_peer_endpoint", "Peers info. static value"),
             &["interface", "endpoint_ip", "peer", "alias"],
         )?;
 
@@ -120,15 +117,17 @@ impl Metrics {
             assert!(p.interface < state.interfaces.len());
 
             if let Some(endpoint) = p.endpoint {
-                self.peer_endpoint.with_label_values(&[
-                    &state.interfaces[p.interface],
-                    &endpoint.ip().to_string(),
-                    &p.pubkey,
-                    &p.alias
-                        .as_ref()
-                        .map(ToOwned::to_owned)
-                        .unwrap_or_else(String::new),
-                ]).set(1);
+                self.peer_endpoint
+                    .with_label_values(&[
+                        &state.interfaces[p.interface],
+                        &endpoint.ip().to_string(),
+                        &p.pubkey,
+                        &p.alias
+                            .as_ref()
+                            .map(ToOwned::to_owned)
+                            .unwrap_or_else(String::new),
+                    ])
+                    .set(1);
             };
 
             let pbtt = self.peer_bytes_total.with_label_values(&[

--- a/src/wireguard.rs
+++ b/src/wireguard.rs
@@ -1,5 +1,4 @@
-use std::collections::HashMap;
-
+use std::{collections::HashMap, str::FromStr, net::SocketAddr};
 use color_eyre::eyre::{Result, WrapErr};
 use tokio::process::Command;
 
@@ -48,7 +47,7 @@ impl WireguardState {
                     Some(_iface),
                     Some(pubkey),
                     Some(_psk),
-                    Some(_endpoint),
+                    Some(endpoint),
                     Some(_allowed_ips),
                     Some(handshake_ts),
                     Some(tx_bytes),
@@ -60,6 +59,7 @@ impl WireguardState {
                         interface: interfaces.len() - 1,
                         alias: aliases.get(pubkey).map(|&s| s.into()),
                         pubkey: pubkey.into(),
+                        endpoint: SocketAddr::from_str(endpoint).ok(),
                         handshake_timestamp: if ts == 0 { None } else { Some(ts) },
                         tx_bytes: tx_bytes.parse()?,
                         rx_bytes: rx_bytes.parse()?,
@@ -87,6 +87,7 @@ impl WireguardState {
 #[derive(Clone, PartialEq, Debug, Default)]
 pub struct Peer {
     pub pubkey: String,
+    pub endpoint: Option<SocketAddr>,
     pub alias: Option<String>,
     pub interface: usize,
     pub tx_bytes: u64,

--- a/src/wireguard.rs
+++ b/src/wireguard.rs
@@ -1,5 +1,5 @@
-use std::{collections::HashMap, str::FromStr, net::SocketAddr};
 use color_eyre::eyre::{Result, WrapErr};
+use std::{collections::HashMap, net::SocketAddr, str::FromStr};
 use tokio::process::Command;
 
 pub async fn wg_show_dump() -> Result<String> {


### PR DESCRIPTION
add gauge metric `wireguard_peer_endpoint` with static value `1` and information about connected peers in the labels.
useful to monitor the addresses of the peers.