### PR TITLE
add country geoip lookup for endpoint addresses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         rust:
           - stable
           - nightly
-          - 1.56.1 # MSRV
+          - 1.58.1 # MSRV
 
     steps:
       - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ tracing = "0.1.25"
 tracing-subscriber = "0.3.1"
 base64 = "0.13.0"
 time = { version = "0.3.5", features = ["local-offset"] }
+maxminddb = "0.24.0"
 
 [build-dependencies]
 clap = "3.0.0-beta.5"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, env, net::IpAddr, str::FromStr};
+use std::{collections::HashMap, env, net::IpAddr, path::PathBuf, str::FromStr};
 
 use clap::{crate_authors, Parser};
 
@@ -27,6 +27,9 @@ pub struct Args {
     /// Add an alias for a given public key in the form of 'pubkey:alias' (separate multiple with commas)
     #[clap(long, short, value_delimiter = ',', multiple_occurrences = true)]
     pub alias: Vec<Alias>,
+    /// Do geoip lookup using Country MMDB from the PATH for 'endpoint_ip' attribute in the 'wireguard_peer_endpoint' metric and add attribute 'endpoint_country'
+    #[clap(short, long, value_name = "PATH")]
+    pub geoip_path: Option<PathBuf>,
 }
 
 impl Args {

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ async fn try_main(args: Args) -> Result<()> {
 
     info!("Registering metrics...");
     let registry = Arc::new(Registry::new());
-    let mut metrics = unwrap_or_exit!(Metrics::new(&registry, &maxminddb_reader));
+    let mut metrics = unwrap_or_exit!(Metrics::new(&registry, maxminddb_reader));
     let scrape_duration = unwrap_or_exit!(IntGauge::new(
         "wireguard_scrape_duration_milliseconds",
         "Duration in milliseconds of the scrape",
@@ -94,7 +94,7 @@ async fn try_main(args: Args) -> Result<()> {
 
         debug!("Updating metrics...");
         metrics
-            .update(&WireguardState::scrape(&aliases).await?, &maxminddb_reader)
+            .update(&WireguardState::scrape(&aliases).await?)
             .await;
         let after = Instant::now();
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -13,14 +13,11 @@ pub struct Metrics {
     bytes_total: IntCounterVec,
     peer_bytes_total: IntCounterVec,
     duration_since_latest_handshake: IntGaugeVec,
-    maxminddb_reader: Option<maxminddb::Reader<Vec<u8>>>
+    maxminddb_reader: Option<maxminddb::Reader<Vec<u8>>>,
 }
 
 impl Metrics {
-    pub fn new(
-        r: &Registry,
-        maxminddb_reader: Option<maxminddb::Reader<Vec<u8>>>,
-    ) -> Result<Self> {
+    pub fn new(r: &Registry, maxminddb_reader: Option<maxminddb::Reader<Vec<u8>>>) -> Result<Self> {
         trace!("Metrics::new");
 
         let interfaces_total = IntGaugeVec::new(
@@ -89,14 +86,11 @@ impl Metrics {
             peer_endpoint,
             peer_bytes_total,
             duration_since_latest_handshake,
-            maxminddb_reader
+            maxminddb_reader,
         })
     }
 
-    pub async fn update(
-        &mut self,
-        state: &WireguardState
-    ) {
+    pub async fn update(&mut self, state: &WireguardState) {
         let it = self.interfaces_total.with_label_values(&[]);
         it.set(state.interfaces.len() as i64);
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::Result;
+use maxminddb::geoip2;
 use prometheus::{IntCounterVec, IntGaugeVec, Opts, Registry};
 use time::OffsetDateTime;
 use tracing::{debug, trace};
@@ -15,7 +16,10 @@ pub struct Metrics {
 }
 
 impl Metrics {
-    pub fn new(r: &Registry) -> Result<Self> {
+    pub fn new(
+        r: &Registry,
+        maxminddb_reader: &Option<maxminddb::Reader<Vec<u8>>>,
+    ) -> Result<Self> {
         trace!("Metrics::new");
 
         let interfaces_total = IntGaugeVec::new(
@@ -33,7 +37,16 @@ impl Metrics {
 
         let peer_endpoint = IntGaugeVec::new(
             Opts::new("wireguard_peer_endpoint", "Peers info. static value"),
-            &["interface", "endpoint_ip", "peer", "alias"],
+            match maxminddb_reader {
+                Some(_) => &[
+                    "interface",
+                    "endpoint_ip",
+                    "endpoint_country",
+                    "peer",
+                    "alias",
+                ],
+                None => &["interface", "endpoint_ip", "peer", "alias"],
+            },
         )?;
 
         let bytes_total = IntCounterVec::new(
@@ -78,7 +91,11 @@ impl Metrics {
         })
     }
 
-    pub async fn update(&mut self, state: &WireguardState) {
+    pub async fn update(
+        &mut self,
+        state: &WireguardState,
+        maxminddb_reader: &Option<maxminddb::Reader<Vec<u8>>>,
+    ) {
         let it = self.interfaces_total.with_label_values(&[]);
         it.set(state.interfaces.len() as i64);
 
@@ -117,8 +134,32 @@ impl Metrics {
             assert!(p.interface < state.interfaces.len());
 
             if let Some(endpoint) = p.endpoint {
-                self.peer_endpoint
-                    .with_label_values(&[
+                match maxminddb_reader {
+                    Some(reader) => {
+                        let endpoint_country = match reader.lookup::<geoip2::Country>(endpoint.ip())
+                        {
+                            Ok(reader_response) => {
+                                reader_response.country.map_or_else(String::new, |c| {
+                                    c.iso_code
+                                        .map(|code| code.to_string())
+                                        .unwrap_or_else(String::new)
+                                })
+                            }
+                            _ => String::new(),
+                        };
+
+                        self.peer_endpoint.with_label_values(&[
+                            &state.interfaces[p.interface],
+                            &endpoint.ip().to_string(),
+                            &endpoint_country.to_string(),
+                            &p.pubkey,
+                            &p.alias
+                                .as_ref()
+                                .map(ToOwned::to_owned)
+                                .unwrap_or_else(String::new),
+                        ])
+                    }
+                    None => self.peer_endpoint.with_label_values(&[
                         &state.interfaces[p.interface],
                         &endpoint.ip().to_string(),
                         &p.pubkey,
@@ -126,8 +167,9 @@ impl Metrics {
                             .as_ref()
                             .map(ToOwned::to_owned)
                             .unwrap_or_else(String::new),
-                    ])
-                    .set(1);
+                    ]),
+                }
+                .set(1);
             };
 
             let pbtt = self.peer_bytes_total.with_label_values(&[


### PR DESCRIPTION
* add CLI option 'geoip_path' to specify Country MMDB path
* add attribute 'endpoint_country' to the 'wireguard_peer_endpoint' metric if 'geoip_path' was specified