### PR TITLE
clear peer_endpoint on metrics update

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -125,6 +125,8 @@ impl Metrics {
             btr.inc_by(diff);
         }
 
+        self.peer_endpoint.reset();
+
         for p in &state.peers {
             assert!(p.interface < state.interfaces.len());
 


### PR DESCRIPTION
fixes stalled wireguard_peer_endpoint metrics on peer IP change for the same publickey